### PR TITLE
Pool fix

### DIFF
--- a/soillib/map/basic.hpp
+++ b/soillib/map/basic.hpp
@@ -42,10 +42,11 @@ struct basic {
 
   soil::slice<T, Index> slice;
 
-  basic(const glm::ivec2 dimension):dimension(dimension){
-    
-  }
-  basic(const config config):dimension(config.dimension){}
+  basic(const glm::ivec2 dimension)
+    :dimension(dimension),slice(dimension){}
+
+  basic(const config config)
+    :basic(config.dimension){}
 
   inline T* get(const glm::ivec2 p) noexcept {
     return slice.get(p);

--- a/soillib/map/layer.hpp
+++ b/soillib/map/layer.hpp
@@ -108,8 +108,11 @@ struct layer {
 
   soil::slice<cell, Index> slice;
 
-  layer(const glm::ivec2 dimension):dimension(dimension){}
-  layer(const config config):dimension(config.dimension){}
+  layer(const glm::ivec2 dimension)
+    :dimension(dimension),slice(dimension){}
+
+  layer(const config config)
+    :layer(config.dimension){}
 
   inline cell* get(const glm::ivec2 p) noexcept {
     return slice.get(p);

--- a/soillib/util/buf.hpp
+++ b/soillib/util/buf.hpp
@@ -6,18 +6,28 @@
 namespace soil {
 
 /************************************************
-buf is an (optionally) owning raw-data extent,
+buf is an owning raw-data extent,
 with a built-in iterator. This acts as a basis
 for a nuber of memory-pooling concepts.
 ************************************************/
 
 template<typename T> struct buf_iterator;
 template<typename T> struct buf {
+
   T* start = NULL;
   size_t size = 0;
 
+  buf(size_t size):size(size){
+    start = new T[size];
+  }
+
+  ~buf(){
+    delete[] start;
+  }
+
   const buf_iterator<T> begin() const noexcept { return buf_iterator<T>(start, 0); }
   const buf_iterator<T> end()   const noexcept { return buf_iterator<T>(start, size); }
+
 };
 
 template<typename T> struct buf_iterator {

--- a/soillib/util/pool.hpp
+++ b/soillib/util/pool.hpp
@@ -10,106 +10,27 @@ namespace soil {
 
 /*************************************************
 pool is a basic fixed-size allocation memory pool
-for retrieving sub-slices of larger pools, as well
-as in place construction and data returning.
+for retrieving individual elements through in-place
+construction.
 
 todo:
 - use crtp to register the overall size of all
   pools, for static estimation of whether or not
-  the program will run out of memory.
+  the program will run out of memory. maybe?
 - add a set sorting to make fewer fragmented data
   segments
-- add in-place single element construct and get
 *************************************************/
-
-// Note: The two pool types below should be unified somehow.
-
-// Full-Bucket Pool
 
 template<typename T>
 struct pool {
 
   soil::buf<T> root;          // Owning Memory Segment
-  std::deque<buf<T>> free;    // Reference to Available Memory
-
-  pool(){}
-  pool(size_t _size){
-    reserve(_size);
-  }
-
-  ~pool(){
-    clear();
-  }
-
-  // Bulk Manipulations
-
-  void reserve(size_t _size){
-    root.size = _size;
-    root.start = new T[root.size];
-    free.emplace_front(root.start, root.size);
-  }
-
-  void clear(){
-    free.clear();
-    if(root.start != NULL){
-      delete[] root.start;
-      root.start = NULL;
-      root.size = 0;
-    }
-  }
-
-  // Data Retrieval and Returning
-
-  buf<T> get(size_t _size){
-
-    if(free.empty())
-      return {NULL, 0};
-
-    if(_size > root.size)
-      return {NULL, 0};
-
-    if(free.front().size < _size)
-      return {NULL, 0};
-
-    buf<T> sec = {free.front().start, _size};
-    free.front().start += _size;
-    free.front().size -= _size;
-
-    return sec;
-
-  }
-
-};
-
-template<typename T>
-struct pool_t {
-
-  soil::buf<T> root;          // Owning Memory Segment
   std::deque<T*> free;         // Reference to Available Memory
 
-  pool_t(){}
-  pool_t(size_t _size){
-    reserve(_size);
-  }
-
-  ~pool_t(){
-    clear();
-  }
-
-  void reserve(size_t _size){
-    root.size = _size;
-    root.start = new T[root.size];
+  pool(){}
+  pool(size_t size):root(size){
     for(size_t i = 0; i < root.size; ++i)
       free.emplace_front(root.start + i);
-  }
-
-  void clear(){
-    free.clear();
-    if(root.start != NULL){
-      delete[] root.start;
-      root.start = NULL;
-      root.size = 0;
-    }
   }
 
   // Data Retrieval and Returning

--- a/soillib/util/slice.hpp
+++ b/soillib/util/slice.hpp
@@ -20,7 +20,10 @@ struct slice {
   soil::buf<T> root;
   glm::ivec2 res = glm::ivec2(0);
 
-  const inline size_t size(){
+  slice(const glm::ivec2 res)
+    :res(res),root(res.x*res.y){}
+
+  const inline size_t size() const {
     return res.x * res.y;
   }
 

--- a/tools/basic_hydrology/source/world.hpp
+++ b/tools/basic_hydrology/source/world.hpp
@@ -81,7 +81,6 @@ struct World {
 
   const size_t SEED;
   soil::map::basic<cell, ind_type> map;
-  soil::pool<cell> cellpool;
 
   static world_c config;
 
@@ -91,13 +90,11 @@ struct World {
   float no_basin_track = 0;
 
   World(size_t SEED):
-    SEED(SEED),
     map(config.map_config),
-    cellpool(map.area)
+    SEED(SEED)
   {
 
     soil::dist::seed(SEED);
-    map.slice = { cellpool.get(map.area), map.dimension };
 
     soil::noise::sampler sampler;
     sampler.source.SetFractalOctaves(8.0f);

--- a/tools/basic_hydrology_mixture/source/world.hpp
+++ b/tools/basic_hydrology_mixture/source/world.hpp
@@ -85,7 +85,6 @@ struct World {
 
   const size_t SEED;
   soil::map::basic<cell, ind_type> map;
-  soil::pool<cell> cellpool;
 
   static world_c config;
 
@@ -96,12 +95,10 @@ struct World {
 
   World(size_t SEED):
     SEED(SEED),
-    map(config.map_config),
-    cellpool(map.area)
+    map(config.map_config)
   {
 
     soil::dist::seed(SEED);
-    map.slice = { cellpool.get(map.area), map.dimension };
 
     soil::noise::sampler sampler;
     sampler.source.SetFractalOctaves(8.0f);

--- a/tools/basic_hydrology_porosity/source/world.hpp
+++ b/tools/basic_hydrology_porosity/source/world.hpp
@@ -83,7 +83,6 @@ struct World {
 
   const size_t SEED;
   soil::map::basic<cell, ind_type> map;
-  soil::pool<cell> cellpool;
 
   static world_c config;
 
@@ -94,12 +93,10 @@ struct World {
 
   World(size_t SEED):
     SEED(SEED),
-    map(config.map_config),
-    cellpool(map.area)
+    map(config.map_config)
   {
 
     soil::dist::seed(SEED);
-    map.slice = { cellpool.get(map.area), map.dimension };
 
     soil::noise::sampler sampler;
     sampler.source.SetFractalOctaves(8.0f);

--- a/tools/basic_wind/config.yaml
+++ b/tools/basic_wind/config.yaml
@@ -3,7 +3,7 @@ scale: 80
 map:
   dimension:
     - 512
-      512
+    - 512
 wind:
   max-age: 1024
   gravity: 0.1

--- a/tools/basic_wind/main.cpp
+++ b/tools/basic_wind/main.cpp
@@ -5,6 +5,13 @@
 
 #include "source/world.hpp"
 #include <iostream>
+#include <csignal>
+
+bool quit = false;
+
+void sighandler(int signal){
+  quit = true;
+}
 
 int main( int argc, char* args[] ) {
 
@@ -18,7 +25,8 @@ int main( int argc, char* args[] ) {
   try {
     World::config = config.As<world_c>();
   } catch(soil::io::yaml::exception e){
-    std::cout<<"failed to parse yaml configuration: "<<e.what()<<std::endl; 
+    std::cout<<"failed to parse yaml configuration: "<<e.what()<<std::endl;
+    return 0;
   }
 
   // Initialize World
@@ -35,11 +43,9 @@ int main( int argc, char* args[] ) {
   size_t n_timesteps = 1024;
   size_t n_cycles = 512;
 
-  while(n_timesteps > 0){
-
-    std::cout<<n_timesteps--<<std::endl;
-    world.erode(n_cycles);
-
+  signal(SIGINT, &sighandler);
+  while(!quit && world.erode(n_cycles) && n_timesteps > 0){
+    std::cout<<n_timesteps--<<std::endl;    
   }
 
   soil::io::tiff height(world.map.dimension);

--- a/tools/basic_wind/source/world.hpp
+++ b/tools/basic_wind/source/world.hpp
@@ -68,18 +68,15 @@ public:
 
   const size_t SEED;
   soil::map::basic<cell, ind_type> map;
-  soil::pool<cell> cellpool;
 
   static world_c config;
 
   World(size_t SEED):
     SEED(SEED),
-    map(config.map_config),
-    cellpool(map.area)
+    map(config.map_config)
   {
 
     soil::dist::seed(SEED);
-    map.slice = { cellpool.get(map.area), map.dimension };
 
     for(auto [cell, pos]: map){
       cell.massflow = 0.0f;

--- a/tools/layer_hydrology/source/world.hpp
+++ b/tools/layer_hydrology/source/world.hpp
@@ -90,8 +90,7 @@ struct World {
 
   const size_t SEED;
   soil::map::layer<cell, segment, ind_type> map;
-  soil::pool<soil::map::layer_cell<cell, segment>> cellpool;
-  soil::pool_t<soil::map::layer_segment<segment>> segpool;
+  soil::pool<soil::map::layer_segment<segment>> segpool;
 
   static world_c config;
 
@@ -103,13 +102,10 @@ struct World {
   World(size_t SEED):
     SEED(SEED),
     map(config.map_config),
-    cellpool(map.area),
     segpool(map.area*16)
   {
 
     soil::dist::seed(SEED);
-
-    map.slice = { cellpool.get(map.area), map.dimension };
 
     soil::noise::sampler sampler;
     sampler.source.SetFractalOctaves(8.0f);

--- a/tools/map_normal/main.cpp
+++ b/tools/map_normal/main.cpp
@@ -22,12 +22,9 @@ struct world_t {
 
   const glm::ivec2 dim;
   soil::map::basic<cell> map;
-  soil::pool<cell> cellpool;
 
-  world_t(const glm::ivec2 dim):
-  dim(dim),map(dim),cellpool(map.area){
-    map.slice = { cellpool.get(map.area), dim };
-  }
+  world_t(const glm::ivec2 dim)
+    :dim(dim),map(dim){}
 
   const inline bool oob(glm::vec2 p){
     return map.oob(p);

--- a/tools/map_relief/main.cpp
+++ b/tools/map_relief/main.cpp
@@ -32,8 +32,6 @@ int main(int argc, char *args[]) {
 
   const glm::ivec2 dim = glm::ivec2(height.width, height.height);
   soil::map::basic<cell> map(dim);
-  soil::pool<cell> cellpool(map.area);
-  map.slice = { cellpool.get(map.area), dim };
 
   // Fill Cell Pool w. Image
 

--- a/tools/quad_hydrology/source/world.hpp
+++ b/tools/quad_hydrology/source/world.hpp
@@ -79,7 +79,6 @@ struct World {
 
   const size_t SEED;
   soil::map::quad<cell, ind_type> map;
-  soil::pool<cell> cellpool;
 
   static world_c config;
 
@@ -90,15 +89,10 @@ struct World {
 
   World(size_t SEED):
     SEED(SEED),
-    map(config.map_config),
-    cellpool(map.area)
+    map(config.map_config)
   {
 
-
     soil::dist::seed(SEED);
-    for(auto& node: map.nodes){
-      node.slice = { cellpool.get(node.area), node.dimension };
-    }
 
     soil::noise::sampler sampler;
     sampler.source.SetFractalOctaves(8.0f);

--- a/tools/view/main.cpp
+++ b/tools/view/main.cpp
@@ -36,8 +36,6 @@ int main( int argc, char* args[] ) {
 
   const glm::ivec2 dim = glm::ivec2(height.width, height.height);
   soil::map::basic<cell> map(dim);
-  soil::pool<cell> cellpool(map.area);
-  map.slice = { cellpool.get(map.area), dim };
 
   // Fill Map
 


### PR DESCRIPTION
This PR merges the basic_wind fix as well as a restructuring of the buf, pool and slice util classes so that buf is owning, pool is fixed-size single element retrieval and slice is a 2D buf view. The ownership of buf removes the necessity of the segmented pool, and maps can be simply memory owning. The reason for doing it the other way in the first place was to cover an edge case, which I haven't gotten around to implementing. Since this is more clean for all other cases, I will cross that bridge when I get there.