### PR TITLE
Fix deprecated CUDA `find_package` in CMakeLists.txt and ensure `erosion_gpu_multiscale.py` runs correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.28)
 project(soillib LANGUAGES CXX CUDA)
 
 include(FetchContent)
@@ -20,12 +20,14 @@ if(NOT Python3_LIBRARIES)
 endif()
 
 # Find CUDA
-find_package(CUDA REQUIRED)
-if(CUDA_FOUND)
-  message(STATUS "CUDA found: ${CUDA_VERSION} at ${CUDA_TOOLKIT_ROOT_DIR}")
+find_package(CUDAToolkit REQUIRED)
+
+if(CUDAToolkit_FOUND)
+  message(STATUS "CUDA found: ${CUDAToolkit_VERSION} at ${CUDAToolkit_LIBRARY_DIR}")
 else()
-  message(FATAL_ERROR "CUDA not found. Please install CUDA.")
+  message(FATAL_ERROR "CUDA Toolkit not found. Please install CUDA.")
 endif()
+
 
 # Fetch dependencies
 FetchContent_Declare(
@@ -110,7 +112,7 @@ target_compile_options(soillib PRIVATE
 # Ensure the compiler can find headers
 target_include_directories(soillib PRIVATE
   ${SOILLIB_INCLUDE_DIR}
-  ${CUDA_INCLUDE_DIRS}    # For cuda_runtime.h
+  ${CUDAToolkit_INCLUDE_DIRS}
   ${Python3_INCLUDE_DIRS}
   ${nanobind_SOURCE_DIR}/include
   ${nanobind_SOURCE_DIR}/ext/robin_map/include

--- a/example/erosion_gpu_multiscale.py
+++ b/example/erosion_gpu_multiscale.py
@@ -132,12 +132,13 @@ def main():
   height = model.height
   soil.add(height, model.sediment)
 
-  tiff_out = soil.geotiff(height.cpu(), index)
-  tiff_out.meta.scale = pscale  # Pixel Scale Important!
-  tiff_out.write("/home/nickmcdonald/Datasets/erosion_gpu_multi.tiff")
+  # tiff_out = soil.geotiff(height.cpu(), index)
+  # tiff_out.meta.scale = pscale  # Pixel Scale Important!
+  # tiff_out.write("/home/nickmcdonald/Datasets/erosion_gpu_multi.tiff")
 
 #  show_layers([model.height, model.sediment], index, pscale)
-  show_relief(height, index, pscale)
+  show_relief(height.cpu(), index, pscale)
+
 #  show_discharge(model.discharge, index)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi Nick,

- **CMake Deprecation Fix**: Updated `CMakeLists.txt` to use `find_package(CUDAToolkit REQUIRED)` instead of the deprecated `find_package(CUDA REQUIRED)`.  
- **Fixed `erosion_gpu_multiscale.py` Execution**:  
  - Commented out the hardcoded GeoTIFF output path to avoid issues.  
  - Ensured compatibility with `matplotlib` by explicitly moving `height` to the CPU before visualization.  

Let me know if you need any changes!  

Best,
David (Robodrome)